### PR TITLE
Use --findUnseenEdges to find unseen edges within the graph

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 TERARKDBROOT = /home/vondele/chess/noob/terarkdb
 CDBDIRECTROOT = /home/vondele/chess/vondele/cdbdirect
+CHESSDB_PATH = /mnt/ssd/chess-20240814/data
 
 LDFLAGS = -L$(TERARKDBROOT)/output/lib -L$(CDBDIRECTROOT)
 LIBS = -lcdbdirect -lterarkdb -lterark-zip-r -lboost_fiber -lboost_context -ltcmalloc -pthread -lgcc -lrt -ldl -ltbb -laio -lgomp -lsnappy -llz4 -lz -lbz2
@@ -7,7 +8,7 @@ LIBS = -lcdbdirect -lterarkdb -lterark-zip-r -lboost_fiber -lboost_context -ltcm
 all: cdbtreesearch cdbtreesearchnosoft
 
 CXXFLAGS = -std=c++20 -O3 -g -march=native -fno-omit-frame-pointer -fno-inline
-CXXFLAGS = -std=c++20 -O3 -g -march=native
+CXXFLAGS += -DCHESSDB_PATH=\"$(CHESSDB_PATH)\"
 
 cdbtreesearchnosoft: main.cpp
 	g++ $(CXXFLAGS) -I$(CDBDIRECTROOT) -o cdbtreesearchnosoft main.cpp $(LDFLAGS) $(LIBS)

--- a/main.cpp
+++ b/main.cpp
@@ -250,6 +250,9 @@ int main(int argc, char const *argv[]) {
   if (find_argument(args, pos, "--fen"))
     fen = {*std::next(pos)};
 
+  if (fen == "startpos")
+    fen = constants::STARTPOS;
+
   // (initial) depth for searches
   int depth = 0;
   if (find_argument(args, pos, "--depth"))
@@ -274,7 +277,7 @@ int main(int argc, char const *argv[]) {
   Board board(fen);
 
   std::cout << "Opening DB" << std::endl;
-  std::uintptr_t handle = cdbdirect_initialize("/mnt/ssd/chess-20240814/data");
+  std::uintptr_t handle = cdbdirect_initialize(CHESSDB_PATH);
 
   Stats stats;
   if (do_pvsearch) {

--- a/softmax.cpp
+++ b/softmax.cpp
@@ -121,7 +121,7 @@ search_result_t gameOver(Board &board, int depth) {
 
 int count_unseen_moves(Board &board,
                        std::vector<std::pair<std::string, int>> &result,
-                       const std::uintptr_t handle, Stats &stats) {
+                       const std::uintptr_t handle) {
   int count_unseen = 0;
   Movelist moves;
   movegen::legalmoves(moves, board);
@@ -140,7 +140,6 @@ int count_unseen_moves(Board &board,
     if (it == result.end()) {
       board.makeMove<true>(m);
       auto r = cdbdirect_get(handle, board.getFen(false));
-      stats.gets++;
       if (r.back().second != -2)
         count_unseen++;
       board.unmakeMove(m);
@@ -186,7 +185,7 @@ search_result_t softmax(Board &board, int depth, double base, bool deriv,
   stats.hits++;
 
   if (fens_with_unseen) {
-    int count_unseen = count_unseen_moves(board, result, handle, stats);
+    int count_unseen = count_unseen_moves(board, result, handle);
     if (count_unseen) {
       PackedBoard pbfen = Board::Compact::encode(board);
       fens_with_unseen->lazy_emplace_l(
@@ -319,7 +318,7 @@ search_result_t cdbsoftmax(Board &board, double base, size_t budget,
   stats.hits++;
 
   if (fens_with_unseen) {
-    int count_unseen = count_unseen_moves(board, result, handle, stats);
+    int count_unseen = count_unseen_moves(board, result, handle);
     if (count_unseen) {
       PackedBoard pbfen = Board::Compact::encode(board);
       fens_with_unseen->lazy_emplace_l(

--- a/softmax.cpp
+++ b/softmax.cpp
@@ -119,9 +119,41 @@ search_result_t gameOver(Board &board, int depth) {
   return std::make_pair(double(0), -1);
 }
 
+int count_unseen_moves(Board &board,
+                       std::vector<std::pair<std::string, int>> &result,
+                       const std::uintptr_t handle, Stats &stats) {
+  int count_unseen = 0;
+  Movelist moves;
+  movegen::legalmoves(moves, board);
+
+  int unscored_total = moves.size() + 1 - result.size();
+  int unscored_checked = 0;
+
+  // check if the position after any unscored move is in the DB
+  for (const auto &m : moves) {
+    if (unscored_checked >= unscored_total)
+      break;
+    auto it = std::find_if(result.begin(), result.end(), [&m](const auto &p) {
+      return p.first == uci::moveToUci(m);
+    });
+
+    if (it == result.end()) {
+      board.makeMove<true>(m);
+      auto r = cdbdirect_get(handle, board.getFen(false));
+      stats.gets++;
+      if (r.back().second != -2)
+        count_unseen++;
+      board.unmakeMove(m);
+      unscored_checked++;
+    }
+  }
+  return count_unseen;
+}
+
 search_result_t softmax(Board &board, int depth, double base, bool deriv,
                         fen_map_t &fen_map, Stats &stats, const double alpha,
-                        const std::uintptr_t handle, const bool showTree) {
+                        const std::uintptr_t handle, const bool showTree,
+                        fen_map_t *fens_with_unseen) {
 
   stats.nodes++;
   search_result_t ret = gameOver(board, depth);
@@ -153,6 +185,18 @@ search_result_t softmax(Board &board, int depth, double base, bool deriv,
 
   stats.hits++;
 
+  if (fens_with_unseen) {
+    int count_unseen = count_unseen_moves(board, result, handle, stats);
+    if (count_unseen) {
+      PackedBoard pbfen = Board::Compact::encode(board);
+      fens_with_unseen->lazy_emplace_l(
+          std::move(pbfen), [](fen_map_t::value_type &p) {},
+          [&pbfen, &count_unseen](const fen_map_t::constructor &ctor) {
+            ctor(std::move(pbfen), count_unseen);
+          });
+    }
+  }
+
   // collect for all the cdb moves the softmax values
   std::vector<std::pair<std::string, double>> softmaxes;
   softmaxes.reserve(result.size() - 1);
@@ -169,7 +213,7 @@ search_result_t softmax(Board &board, int depth, double base, bool deriv,
         board.makeMove<true>(m);
         search_result_t moveresult =
             softmax(board, depth - 1, base, false, fen_map, stats, alpha,
-                    handle, showTree);
+                    handle, showTree, fens_with_unseen);
         board.unmakeMove(m);
         if (moveresult.second < 0)
           softmaxes.emplace_back(
@@ -220,7 +264,7 @@ search_result_t softmax(Board &board, int depth, double base, bool deriv,
         Move m = uci::uciToMove(board, pair.first);
         board.makeMove<true>(m);
         softmax(board, depth - 1, -base * deriv, true, fen_map, stats, alpha,
-                handle, showTree);
+                handle, showTree, fens_with_unseen);
         board.unmakeMove(m);
       }
     }
@@ -238,7 +282,8 @@ std::array<ThreadPool, 8> threadpools{};
 //
 search_result_t cdbsoftmax(Board &board, double base, size_t budget,
                            fen_map_t &fen_map, Stats &stats, const double alpha,
-                           const std::uintptr_t handle, const bool showTree) {
+                           const std::uintptr_t handle, const bool showTree,
+                           fen_map_t *fens_with_unseen) {
 
   stats.nodes++;
   size_t ply =
@@ -272,6 +317,18 @@ search_result_t cdbsoftmax(Board &board, double base, size_t budget,
   }
 
   stats.hits++;
+
+  if (fens_with_unseen) {
+    int count_unseen = count_unseen_moves(board, result, handle, stats);
+    if (count_unseen) {
+      PackedBoard pbfen = Board::Compact::encode(board);
+      fens_with_unseen->lazy_emplace_l(
+          std::move(pbfen), [](fen_map_t::value_type &p) {},
+          [&pbfen, &count_unseen](const fen_map_t::constructor &ctor) {
+            ctor(std::move(pbfen), count_unseen);
+          });
+    }
+  }
 
   // compute softmax based on cdb values, we'll use that for deriv.
   // for numerical stability, we subtract max from all arguments, and add back
@@ -323,11 +380,11 @@ search_result_t cdbsoftmax(Board &board, double base, size_t budget,
         std::string fen = board.getFen();
 
         auto f = [pair, fen, base, deriv, next_budget, &fen_map, &stats, &alpha,
-                  &handle, &showTree]() {
+                  &handle, &showTree, &fens_with_unseen]() {
           Board board(fen);
           search_result_t moveresult =
               cdbsoftmax(board, -base * deriv, next_budget, fen_map, stats,
-                         alpha, handle, showTree);
+                         alpha, handle, showTree, fens_with_unseen);
           return std::make_pair(pair.first, moveresult.second < 0
                                                 ? double(pair.second)
                                                 : -moveresult.first);
@@ -390,6 +447,13 @@ search_result_t cdbsoftmax(Board &board, double base, size_t budget,
   return std::make_pair(softmaxvalue, 0);
 }
 
+inline size_t sumValues(const fen_map_t &map) {
+  size_t sum = 0;
+  for (const auto &pair : map)
+    sum += pair.second;
+  return sum;
+}
+
 int main(int argc, char const *argv[]) {
 
   const std::vector<std::string> args(argv + 1, argv + argc);
@@ -439,6 +503,8 @@ int main(int argc, char const *argv[]) {
   bool showTree = find_argument(args, pos, "--showTree", true);
   bool exact = find_argument(args, pos, "--exact", true);
   bool allmoves = find_argument(args, pos, "--moves", true);
+  bool uncover = find_argument(args, pos, "--findUnseenEdges", true);
+  fen_map_t *fens_with_unseen = uncover ? new fen_map_t : NULL;
 
   std::cout << "Opening DB" << std::endl;
   std::uintptr_t handle = cdbdirect_initialize(CHESSDB_PATH);
@@ -483,14 +549,17 @@ int main(int argc, char const *argv[]) {
 
     if (exact) {
       sr = softmax(board, depth, base, deriv, fen_map, stats, alpha, handle,
-                   showTree);
+                   showTree, fens_with_unseen);
     } else {
       sr = cdbsoftmax(board, base, budget, fen_map, stats, alpha, handle,
-                      showTree);
+                      showTree, fens_with_unseen);
     };
     std::cout << " score " << std::fixed << std::setw(8) << std::setprecision(2)
               << sr.first;
     std::cout << " unknown " << std::setw(10) << fen_map.size();
+    if (fens_with_unseen)
+      std::cout << " fens w/ unseen " << std::setw(10)
+                << fens_with_unseen->size();
     std::cout << " hits    " << std::setw(10) << stats.hits;
     std::cout << " max_ply " << std::setw(10) << stats.max_ply << std::endl;
 
@@ -514,6 +583,20 @@ int main(int argc, char const *argv[]) {
           << deriv << std::endl;
 
   ufile.close();
+
+  if (fens_with_unseen && fens_with_unseen->size()) {
+    std::ofstream ufile("unseen.epd");
+    assert(ufile.is_open());
+    for (const auto &pair : *fens_with_unseen) {
+      auto board = Board::Compact::decode(pair.first);
+      std::string fen = board.getFen(false);
+      ufile << fen << " c0 \"unseen moves: " << pair.second << "\";\n";
+    }
+    ufile.close();
+    std::cout << "Saved " << fens_with_unseen->size()
+              << " positions with a total of " << sumValues(*fens_with_unseen)
+              << " unseen edges in unseen.epd." << std::endl;
+  }
 
   std::cout << "Closing DB" << std::endl;
   handle = cdbdirect_finalize(handle);

--- a/softmax.cpp
+++ b/softmax.cpp
@@ -402,7 +402,7 @@ int main(int argc, char const *argv[]) {
     fen = {*std::next(pos)};
 
   if (fen == "startpos")
-    fen = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq -";
+    fen = constants::STARTPOS;
 
   std::vector<std::string> inputFens;
 
@@ -441,7 +441,7 @@ int main(int argc, char const *argv[]) {
   bool allmoves = find_argument(args, pos, "--moves", true);
 
   std::cout << "Opening DB" << std::endl;
-  std::uintptr_t handle = cdbdirect_initialize("/mnt/ssd/chess-20240814/data");
+  std::uintptr_t handle = cdbdirect_initialize(CHESSDB_PATH);
 
   Stats stats;
 

--- a/softmax.cpp
+++ b/softmax.cpp
@@ -545,20 +545,25 @@ int main(int argc, char const *argv[]) {
     bool deriv = true;
     fen_map_t fen_map;
     search_result_t sr;
+    fen_map_t *local_fens_with_unseen = uncover ? new fen_map_t : NULL;
 
     if (exact) {
       sr = softmax(board, depth, base, deriv, fen_map, stats, alpha, handle,
-                   showTree, fens_with_unseen);
+                   showTree, local_fens_with_unseen);
     } else {
       sr = cdbsoftmax(board, base, budget, fen_map, stats, alpha, handle,
-                      showTree, fens_with_unseen);
+                      showTree, local_fens_with_unseen);
     };
     std::cout << " score " << std::fixed << std::setw(8) << std::setprecision(2)
               << sr.first;
     std::cout << " unknown " << std::setw(10) << fen_map.size();
-    if (fens_with_unseen)
+    if (local_fens_with_unseen) {
       std::cout << " fens w/ unseen " << std::setw(10)
-                << fens_with_unseen->size();
+                << local_fens_with_unseen->size();
+      for (const auto &pair : *local_fens_with_unseen)
+        (*fens_with_unseen)[pair.first] = pair.second;
+      delete local_fens_with_unseen;
+    }
     std::cout << " hits    " << std::setw(10) << stats.hits;
     std::cout << " max_ply " << std::setw(10) << stats.max_ply << std::endl;
 


### PR DESCRIPTION
This mirrors the PR https://github.com/vondele/cdbsubtree/pull/1. Sample usage:
```
> ./cdbtreesearch --inverseAlpha 10 --budget 1000000 --fen startpos --findUnseenEdges
Opening DB
Starting softmax search with alpha 0.1
depth            0
budget      1000000
Search fen:                  rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - after move  none score     0.89 unknown        252 fens w/ unseen      35177 hits        999509 max_ply         29
Saved 35177 positions with a total of 120337 unseen edges in unseen.epd.
Closing DB
```

For simplicity this PR is based on https://github.com/vondele/cdbtreesearch/pull/1, so will open this as draft for now and rebase later.